### PR TITLE
Feat/wrapper option

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,7 +2,7 @@ import babel from 'rollup-plugin-babel';
 import pkg from './package.json';
 
 export default {
-    input: 'src/withAnimation.js',
+    input: 'src/index.js',
     external: ['react', 'prop-types'],
     output: [
         {

--- a/src/container/index.js
+++ b/src/container/index.js
@@ -1,0 +1,20 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import withAnimation, { propTypes } from '../hoc/index';
+
+WithAnimationContainer.propTypes = propTypes;
+
+/*
+    In order to pass a react component to the hoc, we need to create a React element for the div
+*/
+const Div = ({ children, className, style }) => (
+    <div className={className} style={style}>
+        {children}
+    </div>
+);
+
+const Animatee = withAnimation(Div);
+
+export default function WithAnimationContainer(props) {
+    return <Animatee {...props} />;
+}

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { Component } from 'react';
 
-const propTypes = {
+export const propTypes = {
     animationClasses: PropTypes.string.isRequired,
     animationDuration: PropTypes.number,
     animateOnFirstRender: PropTypes.bool,
@@ -13,7 +13,7 @@ const defaultProps = {
 };
 
 export default function withAnimation(WrappedComponent) {
-    class ComponentWithAnimation extends React.Component {
+    class ComponentWithAnimation extends Component {
         constructor() {
             super();
             this.state = {
@@ -50,18 +50,13 @@ export default function withAnimation(WrappedComponent) {
         render() {
             const { isAnimating } = this.state;
             const { animationClasses, animationDuration, children, wrappedRef, className, style } = this.props;
-            const classes = []
-                .concat(className ? [className] : [])
-                .concat(isAnimating && animationClasses ? [animationClasses] : [])
-                .join(' ');
-
             const componentProps = {
                 ...this.props,
                 style: {
                     ...style,
                     animationDuration: isAnimating ? `${animationDuration}ms` : null,
                 },
-                className: classes,
+                className: `${className ? className : ''} ${isAnimating ? animationClasses : ''}`,
                 ref: wrappedRef,
             };
             return <WrappedComponent {...componentProps}>{children}</WrappedComponent>;

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,3 @@
+import withAnimation from './hoc/index';
+
+export { withAnimation };

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
 import withAnimation from './hoc/index';
+import WithAnimationContainer from './container/index';
 
-export { withAnimation };
+export { withAnimation, WithAnimationContainer };


### PR DESCRIPTION
# The Problem

Currently, the hoc 'mode' applies the `animationClasses` to which ever Component is passed in. This works well as a hoc, but the user must remember to pass `style` and `className` props to their Component or it won't work.

The point of using this as a HOC at first was assuming that you would never want to add CSS animation classes onto any sort of 'containing' element, instead you'd *always* want to 'decorate' your element with these added classes.

This of course is what motivated the HOC in the first place (instead of a Component that takes children). 

Challenge #1 here is that you need to remember to pass style and className, but it also makes the JSX markup a little less obvious in terms of what's going on.

# The Solution
Provide an alternative `<WithAnimationContainer>` component that can be used instead of the hoc.

Usage
```
<WithAnimationContainer animationClasses="foo" animationDuration={x]>
   <MyComponentToBeWrapped />
</WithAnimationContainer>
```
