### PR TITLE
Feat/on animation end

### DIFF
--- a/src/container/index.js
+++ b/src/container/index.js
@@ -7,8 +7,8 @@ WithAnimationContainer.propTypes = propTypes;
 /*
     In order to pass a react component to the hoc, we need to create a React element for the div
 */
-const Div = ({ children, className, style, onAnimationEnd }) => (
-    <div className={className} style={style} onAnimationEnd={onAnimationEnd}>
+const Div = ({ children, className, onAnimationEnd }) => (
+    <div className={className} onAnimationEnd={onAnimationEnd}>
         {children}
     </div>
 );

--- a/src/container/index.js
+++ b/src/container/index.js
@@ -7,8 +7,8 @@ WithAnimationContainer.propTypes = propTypes;
 /*
     In order to pass a react component to the hoc, we need to create a React element for the div
 */
-const Div = ({ children, className, style }) => (
-    <div className={className} style={style}>
+const Div = ({ children, className, style, onAnimationEnd }) => (
+    <div className={className} style={style} onAnimationEnd={onAnimationEnd}>
         {children}
     </div>
 );

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -21,6 +21,7 @@ export default function withAnimation(WrappedComponent) {
             };
             this.timeoutFunc = null;
             this.startAnimation = this.startAnimation.bind(this);
+            this.handleAnimationEnd = this.handleAnimationEnd.bind(this);
         }
 
         componentWillUnmount() {
@@ -41,10 +42,10 @@ export default function withAnimation(WrappedComponent) {
             clearTimeout(this.timeoutFunc);
 
             this.setState({ isAnimating: true });
+        }
 
-            this.timeoutFunc = setTimeout(() => {
-                this.setState({ isAnimating: false });
-            }, animationDuration);
+        handleAnimationEnd() {
+            this.setState({ isAnimating: false });
         }
 
         render() {
@@ -63,6 +64,7 @@ export default function withAnimation(WrappedComponent) {
                 },
                 className: classes,
                 ref: wrappedRef,
+                onAnimationEnd: this.handleAnimationEnd,
             };
             return <WrappedComponent {...componentProps}>{children}</WrappedComponent>;
         }

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -3,13 +3,11 @@ import React, { Component } from 'react';
 
 export const propTypes = {
     animationClasses: PropTypes.string.isRequired,
-    animationDuration: PropTypes.number,
     animateOnFirstRender: PropTypes.bool,
 };
 
 const defaultProps = {
     animateOnFirstRender: false,
-    animationDuration: 3000,
 };
 
 export default function withAnimation(WrappedComponent) {
@@ -19,13 +17,8 @@ export default function withAnimation(WrappedComponent) {
             this.state = {
                 isAnimating: false,
             };
-            this.timeoutFunc = null;
             this.startAnimation = this.startAnimation.bind(this);
             this.handleAnimationEnd = this.handleAnimationEnd.bind(this);
-        }
-
-        componentWillUnmount() {
-            clearTimeout(this.timeoutFunc);
         }
 
         componentWillMount() {
@@ -38,9 +31,6 @@ export default function withAnimation(WrappedComponent) {
             if (this.state.isAnimating) {
                 return;
             }
-            const { animationDuration } = this.props;
-            clearTimeout(this.timeoutFunc);
-
             this.setState({ isAnimating: true });
         }
 
@@ -50,7 +40,7 @@ export default function withAnimation(WrappedComponent) {
 
         render() {
             const { isAnimating } = this.state;
-            const { animationClasses, animationDuration, children, wrappedRef, className, style } = this.props;
+            const { animationClasses, children, wrappedRef, className, style } = this.props;
             const classes = []
                 .concat(className ? [className] : [])
                 .concat(isAnimating && animationClasses ? [animationClasses] : [])
@@ -58,10 +48,6 @@ export default function withAnimation(WrappedComponent) {
 
             const componentProps = {
                 ...this.props,
-                style: {
-                    ...style,
-                    animationDuration: isAnimating ? `${animationDuration}ms` : null,
-                },
                 className: classes,
                 ref: wrappedRef,
                 onAnimationEnd: this.handleAnimationEnd,


### PR DESCRIPTION
# Motivation
A friendly Twitter user asked why I didn't use `onAnimationEnd` to handle the removal of the animation classes. I had no clear answer, but was intrigued at the prospect!

Here's a PR that successfully implements it. 

# Implications:
- 🎉 No need for passing `animationDuration` as a prop any more  🎉
- Cleanly set `animation-duration` in CSS (the way it should be)

```CSS
.animationClass {
    animation: do-a-flip 3s ease; // now the duration can be set in css!
}
```

```JS
 // no need for also passing animationDuration={xxxx}!
<MyComponentWithAnimation animationClasses="animationClass" />
```

# Still ToDo / Consider
- Not clear yet how to handle multiple iterations of an animation (but will read up more on the docs about the `onAnimationEnd` event 