### PR TITLE
Fix/style identity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,42 +1,42 @@
 {
-  "name": "react-with-animation",
-  "version": "1.0.21",
-  "description": "A higher-order-component (HOC) to manage short-lived CSS animations in react",
-  "main": "dist/bundle.js",
-  "module": "dist/module.js",
-  "scripts": {
-      "build": "rollup -c",
-      "prepare": "npm run build"
-  },
-  "repository": {
-      "type": "git",
-      "url": "git+https://github.com/SmallImprovements/react-with-animation.git"
-  },
-  "keywords": [
-      "react",
-      "animation",
-      "css",
-      "hoc"
-  ],
-  "author": "Lucas Arundell @ Small Improvements",
-  "license": "ISC",
-  "bugs": {
-      "url": "https://github.com/SmallImprovements/react-with-animation/issues"
-  },
-  "homepage": "https://github.com/SmallImprovements/react-with-animation#readme",
-  "devDependencies": {
-      "babel-core": "^6.26.0",
-      "babel-plugin-transform-object-rest-spread": "^6.26.0",
-      "babel-preset-env": "^1.7.0",
-      "babel-preset-react": "^6.24.1",
-      "babel-preset-stage-1": "^6.24.1",
-      "rollup": "^0.53.2",
-      "rollup-plugin-babel": "^3.0.3"
-  },
-  "peerDependencies": {
-      "react": "^15.3.0 || ^16.2.0"
-  },
-  "dependencies": {
-      "prop-types": "^15.6.0"
-  }
+    "name": "react-with-animation",
+    "version": "1.0.3",
+    "description": "A higher-order-component (HOC) to manage short-lived CSS animations in react",
+    "main": "dist/bundle.js",
+    "module": "dist/module.js",
+    "scripts": {
+        "build": "rollup -c",
+        "prepare": "npm run build"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/SmallImprovements/react-with-animation.git"
+    },
+    "keywords": [
+        "react",
+        "animation",
+        "css",
+        "hoc"
+    ],
+    "author": "Lucas Arundell @ Small Improvements",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/SmallImprovements/react-with-animation/issues"
+    },
+    "homepage": "https://github.com/SmallImprovements/react-with-animation#readme",
+    "devDependencies": {
+        "babel-core": "^6.26.0",
+        "babel-plugin-transform-object-rest-spread": "^6.26.0",
+        "babel-preset-env": "^1.7.0",
+        "babel-preset-react": "^6.24.1",
+        "babel-preset-stage-1": "^6.24.1",
+        "rollup": "^0.53.2",
+        "rollup-plugin-babel": "^3.0.3"
+    },
+    "peerDependencies": {
+        "react": "^15.3.0 || ^16.2.0"
+    },
+    "dependencies": {
+        "prop-types": "^15.6.0"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-with-animation",
-  "version": "1.0.18",
+  "version": "1.1.0",
   "description": "A higher-order-component (HOC) to manage short-lived CSS animations in react",
   "main": "dist/bundle.js",
   "module": "dist/module.js",

--- a/src/hoc/index.js
+++ b/src/hoc/index.js
@@ -46,8 +46,8 @@ export default function withAnimation(WrappedComponent) {
         }
 
         setAnimationState(isAnimating) {
-            this.setState({ isAnimating: isAnimating });
             this.computeStyle(this.props.style, isAnimating, this.props.animationDuration);
+            this.setState({ isAnimating: isAnimating });
         }
 
         startAnimation() {


### PR DESCRIPTION
# Motivation
Currently, the component will re-render every time new props are passed. however we only want it to rerender if `style` or `animationDuration` props change. It's happening because of how the `style` object is computed.

Originally reported: https://github.com/SmallImprovements/react-with-animation/issues/3

# Solution
Check if the specific props change, when recompute the style via `this.style`

@jotaen to help 